### PR TITLE
removes Fixnum reference

### DIFF
--- a/lib/zbar/processor.rb
+++ b/lib/zbar/processor.rb
@@ -4,7 +4,7 @@ module ZBar
     # Accepts a hash of configurations
     def initialize(config = nil)
       # This function used to accept an integer refering to the number of threads
-      if config.kind_of?(Fixnum)
+      if config.kind_of?(Integer)
         config = { :threads => config }
       end
       


### PR DESCRIPTION
Since the Ruby-2.4.0 release, Fixnum and Bignum are combined into Integer class. This fix is to remove all Fixnum reference.
```
zbar-0.2.2/lib/zbar/processor.rb:7: warning: constant ::Fixnum is deprecated
```